### PR TITLE
Helm create argument corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ git pull
 Helm allows the usage of a "template" chart when creating other charts, as follows:
 
 ```bash
-$ helm create ${CHART_NAME} --starter=sitewards/chart 
+$ helm create ${CHART_NAME} --starter=sitewards/chart/chart
 ```
 
 Please note: For some reason, older versions of helm created the charts where the files are executable. If this affects your chart, to fix this, run:


### PR DESCRIPTION
The problem:

```
[funkypenguin:~] master ± helm create batman  --starter=sitewards/chart
Creating batman
Error: could not load /Users/funkypenguin/.helm/starters/sitewards/chart: no Chart.yaml exists in directory "/Users/funkypenguin/.helm/starters/sitewards/chart"
[funkypenguin:~] master ± 
```

The solution:

```
[funkypenguin:~] master ± helm create batman --starter=sitewards/chart/chart
Creating batman
[funkypenguin:~] master* ± ls
batman
[funkypenguin:~] master* ± ls batman
Chart.yaml        LICENSE           MAINTAINERS.md    PERSISTENCE.md    README.md         charts            requirements.yaml templates         values.yaml
[funkypenguin:~] master* ±
```